### PR TITLE
JSON Path

### DIFF
--- a/src/Explorer.tsx
+++ b/src/Explorer.tsx
@@ -1,8 +1,15 @@
 import GridView from "./grid/GridView";
+import PathContext, { useNewPathContext } from "./path/PathContext";
 import sample from "./sample.json";
 
 function Explorer() {
-  return <GridView json={sample} />;
+  const pathContext = useNewPathContext();
+
+  return (
+    <PathContext.Provider value={pathContext}>
+      <GridView json={sample} />
+    </PathContext.Provider>
+  );
 }
 
 export default Explorer;

--- a/src/grid/GridView.tsx
+++ b/src/grid/GridView.tsx
@@ -1,5 +1,6 @@
 import jsonpath from "jsonpath";
 import { FC } from "react";
+import { usePathContext } from "../path/PathContext";
 import "./GridView.scss";
 import MapType from "./MapType";
 
@@ -8,11 +9,13 @@ export interface GridViewProps {
 }
 
 const GridView: FC<GridViewProps> = ({ json }) => {
-  const part = jsonpath.query(json, "$");
+  const { path } = usePathContext();
+
+  const part = jsonpath.query(json, path);
 
   return (
     <div className="GridView">
-      <MapType path="$" json={part} />
+      <MapType path={path} json={part} />
     </div>
   );
 };

--- a/src/path/PathContext.ts
+++ b/src/path/PathContext.ts
@@ -1,0 +1,24 @@
+import { createContext, useContext, useState } from "react";
+
+export interface PathContextValue {
+  path: string;
+  setPath(path: string): void;
+}
+
+export const defaultPath = "$";
+
+const PathContext = createContext({
+  path: defaultPath,
+  setPath(_) {},
+} as PathContextValue);
+
+export function useNewPathContext(): PathContextValue {
+  const [path, setPath] = useState(defaultPath);
+  return { path, setPath };
+}
+
+export function usePathContext(): PathContextValue {
+  return useContext(PathContext);
+}
+
+export default PathContext;


### PR DESCRIPTION
The navigation will be managed the jsonpath syntax

This includes a breadcrumb with
- [ ] the current path
- [ ] a virtal path based on what the user is highlighting

The breadcrumb will be rendered
- [ ] on a user friendly way, like a file explorer
- [ ] allow navigation by clicking
- [ ] allow edition as the user wants

The navigation should:
- [ ] sincronize the current path with the url hash, to allow sharable filters
- [ ] allow clicking a key to change the begining of the json
